### PR TITLE
insert comma for sci and eng formats

### DIFF
--- a/common/hp15c.js
+++ b/common/hp15c.js
@@ -755,6 +755,7 @@ function format_sci(n, mag) {
     }
     s = s.substr(0, 1) + '.' + s.substr(1);
     s += "e" + mag;
+    s = insert_commas(s);
     return s;
 }
 
@@ -774,6 +775,7 @@ function format_eng(n, mag) {
     }
     s = s.substr(0, ilen) + '.' + s.substr(ilen);
     s += "e" + mag;
+    s = insert_commas(s);
     return s;
 }
 


### PR DESCRIPTION
When changing from '.' to ',' as decimal separator, this was working only for the "fix" format and not for the "sci" nor the "eng" formats. To fix that, it seems that "s=insert_comma(s);" should be called just before the "return s;" statement in the format_sci and format_eng functions. I did not test this extensively (only on the IOS simulator) but that should fix the issue.
Thanks a lot for this HP15C simulator, I am using it a lot !